### PR TITLE
SPS30 - removing accidentally added code

### DIFF
--- a/src/src/sensor/SPS30.h
+++ b/src/src/sensor/SPS30.h
@@ -97,7 +97,6 @@ class SPS30_PM005 : public GeneralPurposeMeasurement {
     sps30 = sensor;
 
     this->setDefaultUnitAfterValue("μg/m³");
-    this->setInitialCaption("Light sensor 🌞");
   }
 
   double getValue() {


### PR DESCRIPTION
GG is using older SD so I can't set the initial name, what is breaking compilation